### PR TITLE
prevent crashes if osm_type or osm_id are not available

### DIFF
--- a/lib/osm_nominatim.dart
+++ b/lib/osm_nominatim.dart
@@ -269,8 +269,8 @@ class Place {
   // ignore: public_member_api_docs
   factory Place.fromJson(Map<String, dynamic> json) => Place(
         placeId: json['place_id'] as int,
-        osmType: json['osm_type'] as String,
-        osmId: json['osm_id'] as int,
+        osmType: json['osm_type'] != null ? json['osm_type'] as String : null,
+        osmId: json['osm_id'] != null ? json['osm_id'] as int : null,
         boundingBox: (json['boundingbox'] as List<dynamic>)
             .map<String>((e) => e as String)
             .toList(),
@@ -300,10 +300,10 @@ class Place {
   final int placeId;
 
   /// Reference to the OSM object
-  final String osmType;
+  final String? osmType;
 
   /// Reference to the OSM object
-  final int osmId;
+  final int? osmId;
 
   /// Area of corner coordinates
   /// See https://nominatim.org/release-docs/latest/api/Output/#boundingbox


### PR DESCRIPTION
PR fixes #5 

# What has been done

Both `osm_type` or `osm_id` are defined nullable and appropriate processing added to the decoding factory.

# Purpose

Now it is possible to process results of searching `22102 US`:
- in the web https://nominatim.openstreetmap.org/search.php?q=22102+US&format=jsonv2
- in the code `  final searchResult = await Nominatim.searchByName(query: '22102 US');`